### PR TITLE
Updates input variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,6 @@ resource "null_resource" "oc_login" {
   }
 
   provisioner "local-exec" {
-    command = "${path.module}/scripts/oc-login.sh \"${var.server_url}\" \"${var.user}\" \"${var.password}\" \"${var.token}\""
+    command = "${path.module}/scripts/oc-login.sh \"${var.server_url}\" \"${var.login_user}\" \"${var.login_password}\" \"${var.login_token}\""
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,19 +11,19 @@ output "server_url" {
 }
 
 output "config_file_path" {
-  value       = "${local.cluster_config_dir}/config"
+  value       = local.cluster_config
   description = "Path to the config file for the cluster."
   depends_on  = [null_resource.oc_login]
 }
 
 output "platform" {
   value = {
-    kubeconfig = "${local.cluster_config_dir}/config"
+    kubeconfig = local.cluster_config
     type       = "openshift"
     type_code  = "ocp4"
-    version    = ""
-    ingress    = ""
-    tls_secret = ""
+    version    = var.cluster_version
+    ingress    = var.ingress_subdomain
+    tls_secret = var.tls_secret_name
   }
   description = "Configuration values for the cluster platform"
   depends_on  = [null_resource.oc_login]

--- a/test/stages/stage-cluster.tf
+++ b/test/stages/stage-cluster.tf
@@ -2,6 +2,6 @@ module "cluster" {
   source = "./module"
 
   server_url = var.server_url
-  user = "apikey"
-  password = var.ibmcloud_api_key
+  login_user = "apikey"
+  login_password = var.ibmcloud_api_key
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,19 +4,19 @@ variable "server_url" {
   default     = ""
 }
 
-variable "user" {
+variable "login_user" {
   type        = string
   description = "Username for login"
   default     = ""
 }
 
-variable "password" {
+variable "login_password" {
   type        = string
   description = "Password for login"
   default     = ""
 }
 
-variable "token" {
+variable "login_token" {
   type        = string
   description = "Token used for authentication"
   default     = ""
@@ -26,4 +26,22 @@ variable "skip" {
   type        = bool
   description = "Flag indicating that the cluster login has already been performed"
   default     = false
+}
+
+variable "cluster_version" {
+  type        = string
+  description = "The version of the cluster (passed through to the output)"
+  default     = ""
+}
+
+variable "ingress_subdomain" {
+  type        = string
+  description = "The ingress subdomain of the cluster (passed through to the output)"
+  default     = ""
+}
+
+variable "tls_secret_name" {
+  type        = string
+  description = "The name of the secret containing the tls certificates for the ingress subdomain (passed through to the output)"
+  default     = ""
 }


### PR DESCRIPTION
- Renames user, password, and token variables to match ocp-cluster module
- Adds optional cluster_version, ingress_subdomain, and tls_secret_name variables that are passed through to the output

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>